### PR TITLE
Apply fuzzer fixes and minor changes

### DIFF
--- a/src/formats/exr.rs
+++ b/src/formats/exr.rs
@@ -27,6 +27,10 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
             let x_max = read_i32(reader, &Endian::Little)?;
             let y_max = read_i32(reader, &Endian::Little)?;
 
+            if x_min > x_max || y_min > y_max {
+                continue;
+            }
+
             let width = (x_max - x_min + 1) as usize;
             let height = (y_max - y_min + 1) as usize;
 

--- a/src/formats/exr.rs
+++ b/src/formats/exr.rs
@@ -22,10 +22,10 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
 
         if attr_name == "dataWindow" && attr_type == "box2i" {
             // Read the data window values
-            let x_min = read_i32(reader, &Endian::Little)? as isize;
-            let y_min = read_i32(reader, &Endian::Little)? as isize;
-            let x_max = read_i32(reader, &Endian::Little)? as isize;
-            let y_max = read_i32(reader, &Endian::Little)? as isize;
+            let x_min = read_i32(reader, &Endian::Little)? as i64;
+            let y_min = read_i32(reader, &Endian::Little)? as i64;
+            let x_max = read_i32(reader, &Endian::Little)? as i64;
+            let y_max = read_i32(reader, &Endian::Little)? as i64;
 
             if x_min > x_max || y_min > y_max {
                 continue;

--- a/src/formats/exr.rs
+++ b/src/formats/exr.rs
@@ -22,10 +22,10 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
 
         if attr_name == "dataWindow" && attr_type == "box2i" {
             // Read the data window values
-            let x_min = read_i32(reader, &Endian::Little)?;
-            let y_min = read_i32(reader, &Endian::Little)?;
-            let x_max = read_i32(reader, &Endian::Little)?;
-            let y_max = read_i32(reader, &Endian::Little)?;
+            let x_min = read_i32(reader, &Endian::Little)? as isize;
+            let y_min = read_i32(reader, &Endian::Little)? as isize;
+            let x_max = read_i32(reader, &Endian::Little)? as isize;
+            let y_max = read_i32(reader, &Endian::Little)? as isize;
 
             if x_min > x_max || y_min > y_max {
                 continue;

--- a/src/formats/exr.rs
+++ b/src/formats/exr.rs
@@ -10,12 +10,12 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
 
     // Read header attributes until we find the dataWindow attribute
     loop {
-        let attr_name = read_null_terminated_string(reader)?;
+        let attr_name = read_null_terminated_string(reader, 255)?;
         if attr_name.is_empty() {
             break; // End of the header
         }
 
-        let attr_type = read_null_terminated_string(reader)?;
+        let attr_type = read_null_terminated_string(reader, 255)?;
 
         // Skip attr_size
         let attr_size = read_u32(reader, &Endian::Little)?;

--- a/src/formats/hdr.rs
+++ b/src/formats/hdr.rs
@@ -7,10 +7,9 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
 
     // Read the first line and check if it's a valid HDR format identifier
     let mut format_identifier = String::new();
-    // If read_line returns 0, then EOF was reached
-    let amount_read = reader.read_line(&mut format_identifier)?;
+    reader.read_line(&mut format_identifier)?;
 
-    if amount_read == 0 || !format_identifier.starts_with("#?RADIANCE") && !format_identifier.starts_with("#?RGBE") {
+    if !format_identifier.starts_with("#?RADIANCE") && !format_identifier.starts_with("#?RGBE") {
         return Err(
             io::Error::new(io::ErrorKind::InvalidData, "Invalid HDR format identifier").into(),
         );
@@ -18,6 +17,8 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
 
     loop {
         let mut line = String::new();
+
+        // If read_line returns 0, then EOF was reached
         if reader.read_line(&mut line)? == 0 {
             break;
         }

--- a/src/formats/hdr.rs
+++ b/src/formats/hdr.rs
@@ -54,8 +54,8 @@ pub fn size<R: BufRead + Seek>(reader: &mut R) -> ImageResult<ImageSize> {
 }
 
 pub fn matches(header: &[u8]) -> bool {
-    let radiance_header = b"#?RADIANCE";
-    let rgbe_header = b"#?RGBE";
+    let radiance_header = b"#?RADIANCE\n";
+    let rgbe_header = b"#?RGBE\n";
 
     header.starts_with(radiance_header) || header.starts_with(rgbe_header)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,5 @@
 use crate::{ImageError, ImageResult};
-use std::io::{self, BufRead, Read, Seek};
+use std::io::{self, BufRead, Seek};
 
 /// Used for TIFF decoding
 pub enum Endian {
@@ -75,7 +75,7 @@ pub fn read_tag<R: BufRead + Seek>(reader: &mut R) -> ImageResult<(String, usize
     Ok((String::from_utf8_lossy(&tag_buf).into_owned(), size))
 }
 
-pub fn read_null_terminated_string<R: Read>(reader: &mut R, max_size: usize) -> io::Result<String> {
+pub fn read_null_terminated_string<R: BufRead>(reader: &mut R, max_size: usize) -> io::Result<String> {
     let mut bytes = Vec::new();
     let mut amount_read = 0;
 


### PR DESCRIPTION
This is to help out with the PR. I ran a fuzzer on EXR only since that was the one that seemed most likely to fail. I ran into two cases of subtraction overflow so those should be resolved now.

I also went ahead and reverted the `read_null_terminated_string` change I requested earlier in favor of adding a maximum length parameter. This is because while fuzzing EXR was very very slow compared to everything else due to strings not being null terminated all the time. This helps prevent malformed files from causing runaway memory usage.

I also added a newline to the HDR magic numbers because that seems to be part of the spec. Besides the TGA stuff, I feel like HDR is the next most risky because `read_line` has potential to cause runaway memory usage since you don't know when or if a line will end. Because of this fuzzing it is extremely slow since often there aren't very many newlines. I think you can leave it for now, but before release I may rework this to have a maximum string limit before erroring out.